### PR TITLE
add missing include directive necessary to compile some projects

### DIFF
--- a/src/LiveAssetManager.cpp
+++ b/src/LiveAssetManager.cpp
@@ -4,7 +4,7 @@
 //
 //  Created by Simon Geilfus on 17/01/13.
 
-
+#include "cinder/app/App.h"
 #include "LiveAssetManager.h"
 
 LiveAsset::LiveAsset( ci::fs::path relativePath, std::function<void(ci::DataSourceRef)> callback )


### PR DESCRIPTION
Without this change, it wouldn't compile on a Windows project I had (OSX was fine though).
